### PR TITLE
XY-1162: Add source-backed memory knowledge roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # ELF
 
-Evidence-linked fact memory for agents.
+Open-source, source-backed project memory for AI agents.
 
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Language Checks](https://github.com/hack-ink/ELF/actions/workflows/language.yml/badge.svg?branch=main)](https://github.com/hack-ink/ELF/actions/workflows/language.yml)
@@ -15,7 +15,7 @@ Evidence-linked fact memory for agents.
 
 ## What Is ELF?
 
-ELF is a memory service for LLM agents that stores short, evidence-linked facts and retrieves them with chunk-first hybrid search. Postgres with pgvector is the source of truth for notes and embeddings. Qdrant is a derived, rebuildable index for fast candidate retrieval. ELF can also persist evidence-bound entity/relation facts and optionally attach them as `relation_context` in search explain output. ELF exposes both HTTP and MCP interfaces.
+ELF is an open-source source-backed project memory service for AI agents. It lets agents remember project materials, decisions, progress, constraints, preferences, and long-term context without requiring users to re-explain the project. Important memories keep source provenance, lifecycle state, correction and rollback history, and recall-debug evidence. Postgres with pgvector is the source of truth for notes and embeddings. Qdrant is a derived, rebuildable index for fast candidate retrieval. ELF also supports derived knowledge pages, work-journal continuity, reviewable dreaming proposals, context packs, relation context, and HTTP/MCP interfaces.
 
 ## Project Goals
 
@@ -27,12 +27,12 @@ ELF is a memory service for LLM agents that stores short, evidence-linked facts 
 
 ## Why Choose ELF
 
-- Evidence-linked memory with strict provenance requirements.
+- Source-backed project memory with strict provenance requirements.
 - Deterministic `add_note` and LLM-driven `add_event` separation.
 - Postgres source-of-truth plus rebuildable retrieval index.
 - Chunk-first hybrid retrieval with expansion and rerank controls.
 - Multi-tenant scoped APIs for service-style integration.
-- Evaluation tooling (`elf-eval`) for retrieval quality and replay analysis.
+- Evaluation tooling (`elf-eval`) for source-backed memory quality, lifecycle behavior, and replay analysis.
 
 ## Quickstart
 

--- a/apps/elf-eval/src/bin/external_memory_pattern_radar/render.rs
+++ b/apps/elf-eval/src/bin/external_memory_pattern_radar/render.rs
@@ -23,11 +23,13 @@ pub(super) fn render_summary(cursor: &RadarCursor) -> Result<String> {
 	out.push_str("source_refs: []\n");
 	out.push_str("code_refs:\n");
 	out.push_str("  - apps/elf-eval/fixtures/external_memory_pattern_radar/cursor.json\n");
-	out.push_str("  - apps/elf-eval/src/bin/external_memory_pattern_radar.rs\n");
+	out.push_str("  - apps/elf-eval/src/bin/external_memory_pattern_radar/main.rs\n");
+	out.push_str("  - apps/elf-eval/src/bin/external_memory_pattern_radar/render.rs\n");
 	out.push_str("related: []\n");
 	out.push_str("drift_watch:\n");
 	out.push_str("  - apps/elf-eval/fixtures/external_memory_pattern_radar/cursor.json\n");
-	out.push_str("  - apps/elf-eval/src/bin/external_memory_pattern_radar.rs\n");
+	out.push_str("  - apps/elf-eval/src/bin/external_memory_pattern_radar/main.rs\n");
+	out.push_str("  - apps/elf-eval/src/bin/external_memory_pattern_radar/render.rs\n");
 	out.push_str("---\n\n");
 	out.push_str("# External Memory Pattern Radar Summary\n\n");
 	out.push_str("Goal: Preserve the latest weekly ELF external memory pattern radar outcome.\n");

--- a/docs/evidence/2026-06-23-privacy-delete-export-boundaries-drift-audit.md
+++ b/docs/evidence/2026-06-23-privacy-delete-export-boundaries-drift-audit.md
@@ -12,9 +12,9 @@ tags:
   - evidence
   - privacy
   - retention
-source_refs:
-  - docs/runbook/privacy_delete_export.md
+source_refs: []
 code_refs:
+  - docs/runbook/privacy_delete_export.md
   - apps/elf-api/src/routes.rs
   - apps/elf-mcp/src/app/server/tools/docs.rs
   - packages/elf-service/src/docs.rs
@@ -59,7 +59,7 @@ benchmark report.
 Evidence for: `docs/runbook/privacy_delete_export.md` and the related Source
 Library, Knowledge Workspace, graph memory, and core service specs.
 
-## Claims Checked
+## Watched Claims
 
 - Source Library direct and derived readback uses current active source rows for
   recallable snippets.
@@ -75,7 +75,7 @@ Library, Knowledge Workspace, graph memory, and core service specs.
 - Export docs route through authorized read APIs and do not describe a bypass around
   scope, payload level, or write-policy spans.
 
-## Implementation Evidence
+## Evidence Anchors
 
 - `apps/elf-api/src/routes.rs` exposes `DELETE /v2/docs/{doc_id}` through the public
   docs router and OpenAPI path list.
@@ -97,7 +97,7 @@ Library, Knowledge Workspace, graph memory, and core service specs.
   active, unexpired, readable notes and drops malformed relation rows with no
   evidence ids.
 
-## Test Evidence
+Additional test evidence:
 
 - `packages/elf-service/src/knowledge.rs` has pure coverage for deleted, ignored,
   missing, and non-captured source refs.
@@ -115,6 +115,34 @@ Library, Knowledge Workspace, graph memory, and core service specs.
   integration case for Source Library document deletion suppressing page search.
 - `packages/elf-service/tests/acceptance/graph_ingestion.rs` adds an ignored
   integration case for memory-note delete suppressing graph query readback.
+
+## Reverse Checks
+
+- Run `cargo make check-docs` after documentation changes.
+- Run the service acceptance tests named in `code_refs` when changing delete,
+  privacy, export, graph evidence, Knowledge Workspace, or relation-context
+  behavior.
+
+## Verdict
+
+pass
+
+## Required Updates
+
+- If current-recall suppression, retained provenance, Source Library deletion,
+  Knowledge Workspace search, graph evidence, relation context, export, or
+  provider-retention behavior changes, update the runbook, affected specs, tests,
+  and this drift audit together.
+
+## Citations
+
+- `docs/runbook/privacy_delete_export.md`
+- `apps/elf-api/src/routes.rs`
+- `packages/elf-service/src/docs.rs`
+- `packages/elf-service/src/knowledge.rs`
+- `packages/elf-service/src/graph_query.rs`
+- `packages/elf-service/src/graph_report.rs`
+- `packages/elf-service/src/search.rs`
 
 ## Residual Boundaries
 

--- a/docs/evidence/2026-06-27-authority-recovery-drill-drift-audit.md
+++ b/docs/evidence/2026-06-27-authority-recovery-drill-drift-audit.md
@@ -15,7 +15,11 @@ tags:
 source_refs:
   - https://linear.app/hackink/issue/XY-1119
 code_refs:
-  - apps/elf-eval/src/bin/real_world_job_benchmark.rs
+  - apps/elf-eval/src/bin/real_world_job_benchmark/artifacts/recovery.rs
+  - apps/elf-eval/src/bin/real_world_job_benchmark/recovery.rs
+  - apps/elf-eval/src/bin/real_world_job_benchmark/operational/recovery_report.rs
+  - apps/elf-eval/src/bin/real_world_job_benchmark/operational_reports.rs
+  - apps/elf-eval/src/bin/real_world_job_benchmark/validation/recovery_artifact/core.rs
   - apps/elf-eval/fixtures/real_world_memory/production_ops/authority_plane_recovery_drill.json
   - docs/spec/real_world_agent_memory_benchmark_v1.md
   - docs/runbook/benchmarking/real_world_agent_memory_benchmark.md
@@ -23,7 +27,11 @@ related:
   - docs/spec/real_world_agent_memory_benchmark_v1.md
   - docs/runbook/benchmarking/real_world_agent_memory_benchmark.md
 drift_watch:
-  - apps/elf-eval/src/bin/real_world_job_benchmark.rs
+  - apps/elf-eval/src/bin/real_world_job_benchmark/artifacts/recovery.rs
+  - apps/elf-eval/src/bin/real_world_job_benchmark/recovery.rs
+  - apps/elf-eval/src/bin/real_world_job_benchmark/operational/recovery_report.rs
+  - apps/elf-eval/src/bin/real_world_job_benchmark/operational_reports.rs
+  - apps/elf-eval/src/bin/real_world_job_benchmark/validation/recovery_artifact/core.rs
   - apps/elf-eval/fixtures/real_world_memory/production_ops/
   - docs/spec/real_world_agent_memory_benchmark_v1.md
 ---
@@ -57,9 +65,13 @@ or multi-region failover evidence.
 
 ## Evidence Anchors
 
-- `apps/elf-eval/src/bin/real_world_job_benchmark.rs` defines and validates
-  `AuthorityRecoveryDrillArtifact` and aggregates
-  `OperationalAuthorityRecoveryReport`.
+- `apps/elf-eval/src/bin/real_world_job_benchmark/artifacts/recovery.rs` defines
+  `AuthorityRecoveryDrillArtifact`.
+- `apps/elf-eval/src/bin/real_world_job_benchmark/recovery.rs` and
+  `apps/elf-eval/src/bin/real_world_job_benchmark/validation/recovery_artifact/core.rs`
+  validate recovery-drill predicates.
+- `apps/elf-eval/src/bin/real_world_job_benchmark/operational/recovery_report.rs`
+  aggregates `OperationalAuthorityRecoveryReport`.
 - `apps/elf-eval/fixtures/real_world_memory/production_ops/authority_plane_recovery_drill.json`
   encodes one production-ops job with topology, degraded-read labels, RPO/RTO,
   matching before/after authority record counts, replay, rebuild, migration repair,
@@ -88,7 +100,10 @@ pass
 
 ## Citations
 
-- `apps/elf-eval/src/bin/real_world_job_benchmark.rs`
+- `apps/elf-eval/src/bin/real_world_job_benchmark/artifacts/recovery.rs`
+- `apps/elf-eval/src/bin/real_world_job_benchmark/recovery.rs`
+- `apps/elf-eval/src/bin/real_world_job_benchmark/operational/recovery_report.rs`
+- `apps/elf-eval/src/bin/real_world_job_benchmark/validation/recovery_artifact/core.rs`
 - `apps/elf-eval/fixtures/real_world_memory/production_ops/authority_plane_recovery_drill.json`
 - `docs/spec/real_world_agent_memory_benchmark_v1.md`
 - `docs/runbook/benchmarking/real_world_agent_memory_benchmark.md`

--- a/docs/evidence/benchmarking/2026-06-20-knowledge-workspace-version-diff-report.md
+++ b/docs/evidence/benchmarking/2026-06-20-knowledge-workspace-version-diff-report.md
@@ -22,7 +22,7 @@ without turning derived pages into authoritative memory.
 Inputs: `cargo make real-world-memory-live-knowledge`,
 `packages/elf-service/src/knowledge.rs`,
 `apps/elf-eval/src/bin/real_world_live_adapter.rs`, and
-`apps/elf-eval/src/bin/real_world_job_benchmark.rs`.
+`apps/elf-eval/src/bin/real_world_job_benchmark/feature_metrics/knowledge.rs`.
 Outputs: Service and benchmark evidence for `elf.knowledge_page.version_diff/v1`.
 
 ## Executive Judgment
@@ -78,4 +78,3 @@ From `tmp/real-world-memory/live-knowledge/elf-report.json`:
 | XY-1020 | Temporal graph-lite facts can now feed cited pages without making pages source truth. |
 | XY-1021 | Dreaming review queue can propose page rebuilds using source-backed diffs and lint. |
 | Graph/RAG contained adapters | External comparison needs comparable version-diff and citation/lint outputs. |
-

--- a/docs/evidence/benchmarking/2026-06-22-mem0-openmemory-letta-memory-history-core-archive-report.md
+++ b/docs/evidence/benchmarking/2026-06-22-mem0-openmemory-letta-memory-history-core-archive-report.md
@@ -14,11 +14,14 @@ tags:
   - mem0
   - openmemory
   - letta
-source_refs:
-  - apps/elf-eval/fixtures/report_snapshots/2026-06-22-mem0-openmemory-letta-memory-history-core-archive-report.json
-  - apps/elf-eval/fixtures/real_world_external_adapters/mem0_openmemory_letta/
+source_refs: []
 code_refs:
   - Makefile.toml
+  - apps/elf-eval/fixtures/report_snapshots/2026-06-22-mem0-openmemory-letta-memory-history-core-archive-report.json
+  - apps/elf-eval/fixtures/real_world_external_adapters/mem0_openmemory_letta/letta_archival_readback_blocked.json
+  - apps/elf-eval/fixtures/real_world_external_adapters/mem0_openmemory_letta/letta_core_blocks_blocked.json
+  - apps/elf-eval/fixtures/real_world_external_adapters/mem0_openmemory_letta/mem0_sdk_history_export.json
+  - apps/elf-eval/fixtures/real_world_external_adapters/mem0_openmemory_letta/openmemory_ui_export_blocked.json
 related:
   - docs/evidence/benchmarking/2026-06-11-mem0-openmemory-history-ui-export-report.md
   - docs/evidence/benchmarking/2026-06-19-openmemory-ui-export-product-readback-report.md

--- a/docs/evidence/benchmarking/2026-06-22-p1-memory-authority-closeout-report.md
+++ b/docs/evidence/benchmarking/2026-06-22-p1-memory-authority-closeout-report.md
@@ -12,11 +12,14 @@ tags:
   - evidence
   - benchmarking
   - agent-memory
-source_refs:
-  - apps/elf-eval/fixtures/report_snapshots/2026-06-22-p1-memory-authority-closeout-report.json
+source_refs: []
 code_refs:
   - Makefile.toml
-  - apps/elf-eval/fixtures/real_world_memory/p1_closeout/
+  - apps/elf-eval/fixtures/report_snapshots/2026-06-22-p1-memory-authority-closeout-report.json
+  - apps/elf-eval/fixtures/real_world_memory/p1_closeout/correction_persistence_rollback.json
+  - apps/elf-eval/fixtures/real_world_memory/p1_closeout/source_candidate_approval_recall.json
+  - apps/elf-eval/fixtures/real_world_memory/p1_closeout/stale_decision_suppression.json
+  - apps/elf-eval/fixtures/real_world_memory/p1_closeout/unsupported_claim_refusal_work_resume.json
 related:
   - docs/spec/agent_memory_knowledge_system_v1.md
   - docs/spec/real_world_agent_memory_benchmark_v1.md

--- a/docs/evidence/benchmarking/2026-06-22-p2-knowledge-workspace-pageindex-openkb-closeout-report.md
+++ b/docs/evidence/benchmarking/2026-06-22-p2-knowledge-workspace-pageindex-openkb-closeout-report.md
@@ -12,12 +12,15 @@ tags:
   - evidence
   - benchmarking
   - knowledge-workspace
-source_refs:
-  - apps/elf-eval/fixtures/report_snapshots/2026-06-22-p2-knowledge-workspace-pageindex-openkb-closeout-report.json
+source_refs: []
 code_refs:
   - Makefile.toml
-  - apps/elf-eval/fixtures/real_world_memory/source_library/
-  - apps/elf-eval/fixtures/real_world_memory/knowledge/
+  - apps/elf-eval/fixtures/report_snapshots/2026-06-22-p2-knowledge-workspace-pageindex-openkb-closeout-report.json
+  - apps/elf-eval/fixtures/real_world_memory/source_library/long_document_source_library.json
+  - apps/elf-eval/fixtures/real_world_memory/source_library/social_thread_source_library.json
+  - apps/elf-eval/fixtures/real_world_memory/knowledge/changed_source_watch_rebuild.json
+  - apps/elf-eval/fixtures/real_world_memory/knowledge/entity_concept_issue_pages.json
+  - apps/elf-eval/fixtures/real_world_memory/knowledge/project_page_rebuild.json
 related:
   - docs/spec/agent_memory_knowledge_system_v1.md
   - docs/spec/system_knowledge_pages_v1.md

--- a/docs/evidence/benchmarking/2026-06-22-pageindex-openkb-same-corpus-adapter-report.md
+++ b/docs/evidence/benchmarking/2026-06-22-pageindex-openkb-same-corpus-adapter-report.md
@@ -13,11 +13,12 @@ tags:
   - benchmarking
   - pageindex
   - openkb
-source_refs:
-  - apps/elf-eval/fixtures/report_snapshots/2026-06-22-pageindex-openkb-same-corpus-adapter-report.json
-  - apps/elf-eval/fixtures/real_world_external_adapters/pageindex_openkb/
+source_refs: []
 code_refs:
   - Makefile.toml
+  - apps/elf-eval/fixtures/report_snapshots/2026-06-22-pageindex-openkb-same-corpus-adapter-report.json
+  - apps/elf-eval/fixtures/real_world_external_adapters/pageindex_openkb/openkb_wiki_recompile_blocked.json
+  - apps/elf-eval/fixtures/real_world_external_adapters/pageindex_openkb/pageindex_long_document_tree_blocked.json
 related:
   - docs/evidence/benchmarking/2026-06-22-p2-knowledge-workspace-pageindex-openkb-closeout-report.md
   - docs/spec/agent_memory_knowledge_system_v1.md

--- a/docs/evidence/benchmarking/2026-06-23-p3-competitor-strength-absorption-report.md
+++ b/docs/evidence/benchmarking/2026-06-23-p3-competitor-strength-absorption-report.md
@@ -12,14 +12,14 @@ tags:
   - evidence
   - benchmarking
   - p3-closeout
-source_refs:
-  - apps/elf-eval/fixtures/report_snapshots/2026-06-23-p3-competitor-strength-absorption-report.json
+source_refs: []
 code_refs:
   - Makefile.toml
-  - apps/elf-eval/fixtures/real_world_external_adapters/pageindex_openkb/
-  - apps/elf-eval/fixtures/real_world_external_adapters/mem0_openmemory_letta/
-  - apps/elf-eval/fixtures/real_world_external_adapters/graph_rag/
-  - apps/elf-eval/fixtures/real_world_memory/context_trajectory/
+  - apps/elf-eval/fixtures/report_snapshots/2026-06-23-p3-competitor-strength-absorption-report.json
+  - apps/elf-eval/fixtures/real_world_external_adapters/pageindex_openkb/pageindex_long_document_tree_blocked.json
+  - apps/elf-eval/fixtures/real_world_external_adapters/mem0_openmemory_letta/mem0_sdk_history_export.json
+  - apps/elf-eval/fixtures/real_world_external_adapters/graph_rag/graphiti_temporal_validity_blocked.json
+  - apps/elf-eval/fixtures/real_world_memory/context_trajectory/openviking_staged_retrieval_blocked.json
 related:
   - docs/spec/agent_memory_knowledge_system_v1.md
   - docs/evidence/benchmarking/2026-06-19-qmd-debug-ergonomics-dreaming-retest-report.md

--- a/docs/evidence/benchmarking/2026-06-23-p4-production-readiness-evidence-gates-report.md
+++ b/docs/evidence/benchmarking/2026-06-23-p4-production-readiness-evidence-gates-report.md
@@ -12,12 +12,14 @@ tags:
   - evidence
   - benchmarking
   - p4-production-readiness
-source_refs:
-  - apps/elf-eval/fixtures/report_snapshots/2026-06-23-p4-production-readiness-evidence-gates-report.json
-  - apps/elf-eval/fixtures/real_world_memory/production_ops/
+source_refs: []
 code_refs:
   - Makefile.toml
-  - apps/elf-eval/src/bin/real_world_job_benchmark.rs
+  - apps/elf-eval/src/bin/real_world_job_benchmark/main.rs
+  - apps/elf-eval/fixtures/report_snapshots/2026-06-23-p4-production-readiness-evidence-gates-report.json
+  - apps/elf-eval/fixtures/real_world_memory/production_ops/backup_restore_cold_start_readback.json
+  - apps/elf-eval/fixtures/real_world_memory/production_ops/private_manifest_absence_blocked.json
+  - apps/elf-eval/fixtures/real_world_memory/production_ops/resource_envelope_budget.json
 related:
   - docs/spec/real_world_agent_memory_benchmark_v1.md
   - docs/evidence/benchmarking/2026-06-19-operator-approved-public-proxy-production-private-addendum.md

--- a/docs/evidence/benchmarking/2026-06-23-p4-quality-hardening-productization-readiness-report.md
+++ b/docs/evidence/benchmarking/2026-06-23-p4-quality-hardening-productization-readiness-report.md
@@ -12,15 +12,15 @@ tags:
   - evidence
   - benchmarking
   - p4-quality-hardening
-source_refs:
-  - apps/elf-eval/fixtures/report_snapshots/2026-06-23-p4-quality-hardening-productization-readiness-report.json
-  - apps/elf-eval/fixtures/real_world_memory/adversarial_quality/
-  - apps/elf-eval/fixtures/real_world_memory/source_library/
-  - apps/elf-eval/fixtures/real_world_memory/knowledge/
-  - apps/elf-eval/fixtures/real_world_memory/production_ops/
+source_refs: []
 code_refs:
   - Makefile.toml
-  - apps/elf-eval/src/bin/real_world_job_benchmark.rs
+  - apps/elf-eval/src/bin/real_world_job_benchmark/main.rs
+  - apps/elf-eval/fixtures/report_snapshots/2026-06-23-p4-quality-hardening-productization-readiness-report.json
+  - apps/elf-eval/fixtures/real_world_memory/adversarial_quality/unsupported_claim_refusal.json
+  - apps/elf-eval/fixtures/real_world_memory/source_library/long_document_source_library.json
+  - apps/elf-eval/fixtures/real_world_memory/knowledge/changed_source_watch_rebuild.json
+  - apps/elf-eval/fixtures/real_world_memory/production_ops/backup_restore_cold_start_readback.json
 related:
   - docs/spec/agent_memory_knowledge_system_v1.md
   - docs/spec/real_world_agent_memory_benchmark_v1.md

--- a/docs/evidence/benchmarking/2026-06-27-public-quantitative-competitor-scoreboard-report.md
+++ b/docs/evidence/benchmarking/2026-06-27-public-quantitative-competitor-scoreboard-report.md
@@ -12,13 +12,14 @@ tags:
   - evidence
   - benchmarking
   - competitor-scoreboard
-source_refs:
-  - apps/elf-eval/fixtures/report_snapshots/2026-06-27-public-quantitative-competitor-scoreboard-report.json
-  - apps/elf-eval/fixtures/real_world_memory/
-  - apps/elf-eval/fixtures/real_world_external_adapters/
+source_refs: []
 code_refs:
   - Makefile.toml
-  - apps/elf-eval/src/bin/real_world_job_benchmark.rs
+  - apps/elf-eval/src/bin/real_world_job_benchmark/main.rs
+  - apps/elf-eval/fixtures/report_snapshots/2026-06-27-public-quantitative-competitor-scoreboard-report.json
+  - apps/elf-eval/fixtures/real_world_external_adapters/memory_projects_manifest.json
+  - apps/elf-eval/fixtures/real_world_memory/adversarial_quality/unsupported_claim_refusal.json
+  - apps/elf-eval/fixtures/real_world_memory/production_ops/private_manifest_absence_blocked.json
   - apps/elf-eval/tests/real_world_job_benchmark.rs
   - docs/spec/agent_memory_quantitative_benchmark_v1.md
 related:
@@ -28,7 +29,7 @@ related:
 drift_watch:
   - docs/evidence/benchmarking/2026-06-27-public-quantitative-competitor-scoreboard-report.md
   - apps/elf-eval/fixtures/report_snapshots/2026-06-27-public-quantitative-competitor-scoreboard-report.json
-  - apps/elf-eval/src/bin/real_world_job_benchmark.rs
+  - apps/elf-eval/src/bin/real_world_job_benchmark/main.rs
   - docs/spec/agent_memory_quantitative_benchmark_v1.md
   - docs/evidence/benchmarking/index.md
   - README.md

--- a/docs/evidence/benchmarking/2026-07-03-qmd-candidate-replay-comparability-gate.md
+++ b/docs/evidence/benchmarking/2026-07-03-qmd-candidate-replay-comparability-gate.md
@@ -1,3 +1,36 @@
+---
+type: Evidence
+title: "qmd Candidate-Replay Comparability Gate"
+description: "Evidence report for the XY-1156 qmd candidate-replay comparability gate and claim boundary."
+resource: docs/evidence/benchmarking/2026-07-03-qmd-candidate-replay-comparability-gate.md
+status: active
+authority: evidence
+owner: benchmarking
+last_verified: 2026-07-03
+tags:
+  - docs
+  - evidence
+  - benchmarking
+  - qmd
+  - comparability
+source_refs: []
+code_refs:
+  - Makefile.toml
+  - scripts/materialize-qmd-candidate-replay-gate.py
+  - apps/elf-eval/src/bin/real_world_job_benchmark/main.rs
+  - apps/elf-eval/src/bin/real_world_job_benchmark/quantitative.rs
+  - apps/elf-eval/src/bin/real_world_job_benchmark/quantitative_reports.rs
+  - docs/spec/agent_memory_quantitative_benchmark_v1.md
+related:
+  - docs/evidence/benchmarking/2026-06-27-public-quantitative-competitor-scoreboard-report.md
+  - docs/spec/agent_memory_quantitative_benchmark_v1.md
+drift_watch:
+  - Makefile.toml
+  - scripts/materialize-qmd-candidate-replay-gate.py
+  - apps/elf-eval/src/bin/real_world_job_benchmark/quantitative.rs
+  - apps/elf-eval/src/bin/real_world_job_benchmark/quantitative_reports.rs
+  - docs/spec/agent_memory_quantitative_benchmark_v1.md
+---
 # qmd Candidate-Replay Comparability Gate - July 3, 2026
 
 ## Purpose

--- a/docs/evidence/benchmarking/2026-07-03-source-backed-quality-benchmark-harness.md
+++ b/docs/evidence/benchmarking/2026-07-03-source-backed-quality-benchmark-harness.md
@@ -1,3 +1,37 @@
+---
+type: Evidence
+title: "Source-Backed Memory Quality Benchmark Harness"
+description: "Evidence report for the XY-1155 source-backed memory quality benchmark harness, gate metrics, and review result."
+resource: docs/evidence/benchmarking/2026-07-03-source-backed-quality-benchmark-harness.md
+status: active
+authority: evidence
+owner: benchmarking
+last_verified: 2026-07-03
+tags:
+  - docs
+  - evidence
+  - benchmarking
+  - source-backed-memory
+source_refs: []
+code_refs:
+  - Makefile.toml
+  - apps/elf-eval/src/bin/real_world_job_benchmark/main.rs
+  - apps/elf-eval/src/bin/real_world_job_benchmark/source_backed_quality.rs
+  - apps/elf-eval/src/bin/real_world_job_benchmark/markdown/source_backed_quality.rs
+  - apps/elf-eval/src/bin/real_world_job_benchmark/source_backed_quality_reports.rs
+  - docs/spec/agent_memory_knowledge_system_v1.md
+  - docs/spec/real_world_agent_memory_benchmark_v1.md
+related:
+  - docs/evidence/benchmarking/2026-07-03-final-source-backed-project-memory-closeout-report.md
+  - docs/spec/agent_memory_knowledge_system_v1.md
+drift_watch:
+  - Makefile.toml
+  - apps/elf-eval/src/bin/real_world_job_benchmark/main.rs
+  - apps/elf-eval/src/bin/real_world_job_benchmark/source_backed_quality.rs
+  - apps/elf-eval/src/bin/real_world_job_benchmark/markdown/source_backed_quality.rs
+  - apps/elf-eval/src/bin/real_world_job_benchmark/source_backed_quality_reports.rs
+  - docs/spec/agent_memory_knowledge_system_v1.md
+---
 # Source-Backed Memory Quality Benchmark Harness - July 3, 2026
 
 ## Purpose

--- a/docs/evidence/external_memory_pattern_radar_latest.md
+++ b/docs/evidence/external_memory_pattern_radar_latest.md
@@ -14,10 +14,13 @@ tags:
 source_refs: []
 code_refs:
   - apps/elf-eval/fixtures/external_memory_pattern_radar/cursor.json
-  - apps/elf-eval/src/bin/external_memory_pattern_radar.rs
+  - apps/elf-eval/src/bin/external_memory_pattern_radar/main.rs
+  - apps/elf-eval/src/bin/external_memory_pattern_radar/render.rs
 related: []
 drift_watch:
-  - docs/evidence/external_memory_pattern_radar_latest.md
+  - apps/elf-eval/fixtures/external_memory_pattern_radar/cursor.json
+  - apps/elf-eval/src/bin/external_memory_pattern_radar/main.rs
+  - apps/elf-eval/src/bin/external_memory_pattern_radar/render.rs
 ---
 # External Memory Pattern Radar Summary
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -223,3 +223,13 @@ logs.
   reproducible benchmark design. The update records local-model gating, Docker
   digest versus image-ID provenance, journal-to-dreaming promotion checks, and the
   explicit diary/work-journal competitor pattern without changing normative specs.
+
+## 2026-07-05
+
+- Repaired historical OKF evidence metadata so `decodex docs check` passes for the
+  full docs bundle: local fixture/report paths now live in `code_refs`, directory
+  refs were replaced with concrete fixture files, moved benchmark runner refs point
+  at current module files, two July 3 benchmark reports now have Evidence
+  frontmatter, the privacy/delete/export drift audit uses the required Drift Audit
+  headings, and the external memory radar renderer now emits current module-file
+  `code_refs` for regenerated summaries.

--- a/docs/log.md
+++ b/docs/log.md
@@ -153,6 +153,14 @@ logs.
 
 ## 2026-07-03
 
+- Added `docs/reference/plans/2026-07-03-source-backed-memory-knowledge-roadmap.md`
+  to retain the research-backed final roadmap for source-backed project memory,
+  Knowledge Workspace scope management, Work Journal diary behavior, Dreaming Review,
+  model-tier policy, competitor absorption, benchmark metrics, and Decodex execution
+  sequencing.
+- Updated the README positioning copy so the public entry point matches the July 2026
+  source-backed project memory contract instead of the older evidence-linked fact
+  memory phrasing.
 - Updated `docs/spec/agent_memory_knowledge_system_v1.md` for XY-1151 to codify ELF
   as open-source, source-backed project memory for AI agents. The revised contract
   treats Source Library, Memory Authority, Source-to-Memory Authority loop, Knowledge
@@ -210,3 +218,8 @@ logs.
 - Added the R1 local background organizer benchmark evidence report and linked the
   model ladder boundary from the source-backed product, consolidation, memory
   summary, and Work Journal specs.
+- Refined the retained source-backed memory roadmap after bounded research on
+  local model extraction, Work Journal/Dreaming boundaries, competitor adapters, and
+  reproducible benchmark design. The update records local-model gating, Docker
+  digest versus image-ID provenance, journal-to-dreaming promotion checks, and the
+  explicit diary/work-journal competitor pattern without changing normative specs.

--- a/docs/reference/plans/2026-07-03-source-backed-memory-knowledge-roadmap.md
+++ b/docs/reference/plans/2026-07-03-source-backed-memory-knowledge-roadmap.md
@@ -1,0 +1,575 @@
+---
+type: Reference
+title: "Source-Backed Memory Knowledge Roadmap"
+description: "Retained research-backed plan for ELF's source-backed project memory, knowledge workspace, work journal, dreaming, model ladder, competitor absorption, and benchmark roadmap."
+resource: docs/reference/plans/2026-07-03-source-backed-memory-knowledge-roadmap.md
+status: active
+authority: current_state
+owner: reference
+last_verified: 2026-07-04
+tags:
+  - docs
+  - reference
+  - plans
+  - agent-memory
+  - project-memory
+  - knowledge
+source_refs:
+  - https://developers.openai.com/api/docs/guides/model-selection
+  - https://developers.openai.com/api/docs/guides/reasoning-best-practices
+  - https://langchain-ai.github.io/langmem/
+  - https://docs.langchain.com/oss/python/concepts/memory
+  - https://www.letta.com/blog/sleep-time-compute/
+  - https://docs.mem0.ai/cookbooks/companions/local-companion-ollama
+  - https://help.getzep.com/graphiti/configuration/llm-configuration
+  - https://github.com/tobi/qmd
+  - https://github.com/VectifyAI/PageIndex
+  - https://github.com/VectifyAI/OpenKB
+  - https://github.com/plastic-labs/honcho
+  - https://github.com/infiniflow/ragflow
+  - https://microsoft.github.io/graphrag/
+  - https://github.com/HKUDS/LightRAG
+  - https://docs.docker.com/dhi/core-concepts/digests/
+related:
+  - docs/spec/agent_memory_knowledge_system_v1.md
+  - docs/spec/system_context_pack_v1.md
+  - docs/spec/system_work_journal_v1.md
+  - docs/spec/system_memory_summary_v1.md
+  - docs/spec/system_knowledge_pages_v1.md
+  - docs/spec/system_recall_debug_panel_v1.md
+  - docs/evidence/benchmarking/2026-07-03-final-source-backed-project-memory-closeout-report.md
+  - docs/evidence/benchmarking/2026-06-27-public-quantitative-competitor-scoreboard-report.md
+---
+# Source-Backed Memory Knowledge Roadmap
+
+Purpose: Retain the current research-backed execution plan for ELF after competitor
+absorption, small-model review, diary/work-journal review, dreaming review, and
+skeptic challenge.
+
+Status: retained planning artifact. Promote accepted invariants into `docs/spec/`
+before treating them as normative.
+
+## Final Product Decision
+
+ELF should continue as open-source, source-backed project memory for AI agents. The
+knowledge system is required, but it is a supporting workspace for memory quality,
+not a separate generic Knowledge OS.
+
+The user-facing promise is:
+
+> Stop re-explaining your project to AI. ELF turns your project sources into
+> traceable knowledge, promotes reliable knowledge into memory, and shows why each
+> memory was recalled, updated, or rejected.
+
+The internal product contract is:
+
+> Source Library -> Knowledge Workspace, Work Journal, and Dreaming Review ->
+> Memory Authority -> scoped Context Packs -> Recall Engine and Recall Debug.
+
+The differentiation is not raw retrieval alone. The strongest defensible claim is
+source-backed memory authority: provenance, lifecycle, correction, rollback,
+review, scoped recall, and measurable quality.
+
+## Current Baseline
+
+The July 2026 checked-in baseline already supports the product direction:
+
+- `docs/spec/agent_memory_knowledge_system_v1.md` defines the source-backed project
+  memory boundary, supporting capabilities, non-goals, competitor absorption rules,
+  metrics, and phase gates.
+- `docs/evidence/benchmarking/2026-07-03-final-source-backed-project-memory-closeout-report.md`
+  records the current source-backed quality gate with expected evidence recall
+  `1.0`, precision@5 `0.414`, source-ref coverage `1.0`, stale suppression `1.0`,
+  correction persistence `1.0`, delete/tombstone suppression `1.0`, unsupported
+  claim rate `0.0`, Context Pack activation precision/recall `1.0`, and mean
+  latency `2.864ms`.
+- `docs/evidence/benchmarking/2026-06-27-public-quantitative-competitor-scoreboard-report.md`
+  tracks 20 products but explicitly records no comparable product-runtime pass row.
+  This prevents broad "ELF beats everyone" claims.
+
+The current gap is not lack of direction. The gap is turning optimization inputs
+into executable Decodex slices with same-corpus, source-id-mapped, Docker-contained
+benchmark evidence.
+
+The July 4 research pass sharpened three gaps that must remain explicit:
+
+- local model use is technically possible through schema-constrained local runtimes,
+  but ELF currently disables local extraction in the default Docker config and has
+  no benchmark evidence that local models are safe for authority-changing work;
+- Docker benchmark provenance must distinguish immutable image digests from local
+  image IDs and must not turn missing held-out or leakage-audit evidence into a
+  leaderboard claim;
+- Work Journal and Dreaming evidence is strongest when it proves the
+  journal-to-proposal-to-promotion boundary, not when it treats diary text as
+  current memory.
+
+## Small-Model And Strong-Model Policy
+
+Small or local models are a targeted design goal for bounded work after benchmark
+gates pass. The current repository evidence does not yet prove that a small model
+can safely run every background organizer job. Treat small-model use as gated by
+schema validity, citation coverage, unsupported-claim checks, escalation behavior,
+latency, and cost evidence.
+
+The first small-model implementation target should be read-only and proposal-only:
+run a local extractor adapter smoke against `ExtractorOutput`-like JSON Schema,
+materialize reviewable proposals, and score JSON validity, source quote coverage,
+unsupported-claim flags, zero source mutation, review-queue visibility, and
+escalation behavior. Do not persist or auto-apply local-model memory changes until
+that evidence passes.
+
+Use this ladder:
+
+| Tier | Engine | Jobs | Required gates |
+| --- | --- | --- | --- |
+| L0 | Deterministic code | source-id mapping, hashing, schema validation, tombstone checks, scope checks, lifecycle filters, diffing | hard fail on schema/scope/lifecycle violations |
+| L1 | Sparse/vector retrieval | BM25, embeddings, candidate generation, source neighborhood selection | recall, precision, latency, cost, and stale-candidate metrics |
+| L2 | Small/local model | classification, routing, tagging, structured extraction drafts, diary compaction, summary drafts, query expansion, rerank explanation drafts | JSON-schema validity, citation coverage, unsupported-claim lint, confidence thresholds, replay tests |
+| L3 | Strong reasoning model | conflict adjudication, multi-source synthesis, policy-sensitive promotion proposals, contradiction resolution, benchmark judging, roadmap synthesis | independent review, source coverage, disagreement tracking, no silent authority mutation |
+| L4 | Human/operator or explicit policy approval | irreversible deletion policy, public claims, private/provider-backed corpus claims, product-scope decisions | audit log and explicit acceptance |
+
+This means background organization should be designed so cheap models can handle
+repeatable low-risk drafting after they pass evals. Strong models are reserved for
+hard synthesis, ambiguous evidence, and final review gates. The right product shape
+is not "use a small model everywhere"; it is "small model drafts, strong model or
+policy gates promote."
+
+## Latency And Cost Strategy
+
+Hot-path recall must stay fast:
+
+- Retrieve with L0/L1 first.
+- Use precomputed Knowledge Workspace pages, Work Journal summaries, graph-lite
+  facts, and Context Pack manifests.
+- Run L2 model routing only when deterministic routing confidence is low.
+- Keep L3 dreaming/review work asynchronous and batchable.
+
+The expected user experience is conversational: the user asks the agent normally,
+and ELF internally routes memory and knowledge scopes. The user should not manually
+choose packs. `Context Pack` is an internal, traceable transport artifact, not a
+manual user workflow.
+
+## Diary And Work Journal Position
+
+Diary-like memory is valuable, but it should be implemented as Work Journal plus
+Dreaming Review rather than as authoritative memory.
+
+The diary layer should capture:
+
+- session summaries;
+- decisions made and decisions rejected;
+- next steps;
+- blockers;
+- files/issues/sources touched;
+- agent uncertainty and assumptions;
+- handoff notes;
+- cleanup/janitor observations.
+
+The diary layer must not directly become current memory. It becomes evidence that
+can support promotion proposals. This absorbs the "agent should write a diary"
+idea without weakening source-backed authority.
+
+## Dreaming Design
+
+Dreaming is asynchronous, reviewable background organization.
+
+Triggers:
+
+- conversation or task end;
+- source import;
+- source update or deletion;
+- stale-memory detection;
+- repeated recall misses;
+- scheduled daily/weekly maintenance;
+- benchmark failure;
+- explicit "organize this project" command.
+
+Pipeline:
+
+1. L0 validates source refs, lifecycle state, scopes, and schema.
+2. L1 retrieves related memory, sources, pages, journal rows, and traces.
+3. L2 drafts proposals: tags, page deltas, summary updates, candidate memories,
+   duplicate clusters, stale-memory warnings, route hints, and benchmark fixtures.
+4. L0 validators reject malformed, uncited, cross-scope, stale, or unsupported
+   proposals.
+5. L3 reviews only proposals that need synthesis, conflict handling, or authority
+   promotion.
+6. Accepted low-risk derived organization may update derived pages or indexes.
+7. Memory Authority changes require explicit policy acceptance and audit history.
+
+This should make non-frontier models useful because the harness constrains the job,
+but it still keeps strong-model review available where model mistakes would damage
+memory quality.
+
+## Scopes And Automatic Activation
+
+Both knowledge and memory need scope management. Scopes should be automatically
+activated by the router rather than manually selected by users.
+
+Required scope dimensions:
+
+- tenant and project;
+- repository, package, module, or directory;
+- issue, PR, task, incident, milestone, or decision;
+- source collection such as docs, chats, Twitter/X captures, design notes, code
+  references, tickets, or papers;
+- entity such as person, team, product, component, customer, competitor, model, or
+  dependency;
+- time window and lifecycle state;
+- trust tier and privacy boundary;
+- authority layer: source, derived page, journal, proposal, memory, graph, trace.
+
+Automatic Context Routing should produce:
+
+- selected scopes;
+- suppressed scopes;
+- confidence and rationale;
+- budget allocation;
+- source/memory/page/journal/proposal counts;
+- stale and blocked candidates;
+- privacy-safe recall debug output.
+
+Manual overrides should exist for debugging and pinning, but the normal agent path
+must remain automatic.
+
+## Knowledge Workspace Role
+
+The Knowledge Workspace is the bridge between raw source capture and reliable
+memory. It should support:
+
+- source-linked project, entity, concept, issue, decision, author, and timeline
+  pages;
+- tree and outline views for long documents;
+- cross-links between concepts and source refs;
+- stale-source lint;
+- watch/rebuild workflows;
+- version diffs;
+- candidate memory extraction from changed pages;
+- readback through MCP/HTTP for agents.
+
+The workspace must preserve the derived-only boundary. A page can explain and
+organize; it cannot silently become current memory.
+
+## Competitor Absorption Matrix
+
+| Product/reference | Strength to absorb | ELF implementation target | Benchmark gate | Claim boundary |
+| --- | --- | --- | --- | --- |
+| qmd | Local-first hybrid search, BM25 + vector + local rerank, compact top-k/replay ergonomics | one-command recall replay, top-k candidate JSON, dense/sparse/fusion/rerank attribution, dropped-candidate explanations | same-corpus qmd candidate replay with source-id mapping, held-out/leakage evidence, digest, product commit | qmd keeps debug/replay edge until comparable ELF artifacts exist |
+| PageIndex | Long-document tree navigation and traceable reasoning over document hierarchy | Source Library tree artifacts, cited node paths, traversal traces, long-doc route hints | PageIndex same-corpus adapter emits tree artifacts mapped to ELF source ids | no win/tie/loss until product-runtime tree output is comparable |
+| OpenKB | Compiled wiki, concept/entity pages, cross-links, watch/recompile | Knowledge Workspace pages, stale lint, version diffs, source-linked wiki exports | OpenKB same-corpus adapter emits wiki/index/lint/watch artifacts | derived wiki pages are not Memory Authority |
+| mem0/OpenMemory | Drop-in agent memory, entity-scoped history, ADD/UPDATE/DELETE history, local and hosted ecosystem | memory history API, entity-scoped recall, import/export, local SDK recipes, delete audit | local SDK same-corpus history/export and separate OpenMemory UI/export product rows | hosted/UI/export claims require product evidence |
+| Letta | Core/archive split, stateful agents, archival search, sleep-time compute | core project memory blocks, archival source search, sleep-time Dreaming jobs, export/readback mapping | contained Letta export/readback with source ids, core/archive fixtures | no core/archive parity until export/readback maps to ELF ids |
+| Graphiti/Zep | Temporal graph validity, invalidating old facts, vector/full-text/graph retrieval | bitemporal graph-lite facts, valid-from/valid-to, supersession, graph recall labels | temporal-validity adapter with contradiction/staleness cases and source ids | graph-lite evidence is not broad graph/RAG parity |
+| RAGFlow | Deep document understanding, complex PDFs/layout/tables, citation-backed RAG workflows | document parsing adapters, citation navigation, layout/table provenance, ingestion quality gates | Docker adapter with document ids, chunk ids, metadata, stale-source outputs | no document-understanding parity without product-runtime outputs |
+| GraphRAG | Entity/relationship extraction, community summaries, global/local graph retrieval | graph reports, community/topic summaries, local/global scope routing | GraphRAG adapter with documents, text units, communities, reports, entities, relations | no broad graph superiority from ELF-native graph-lite only |
+| LightRAG | Lightweight graph + vector retrieval, local/global/hybrid/mix modes, API/UI | efficient graph/vector hybrid recall, mode-specific traces, KG export comparison | LightRAG adapter emits context, file paths, snippets, source refs, answer checks | incomplete/not-encoded rows stay non-pass |
+| Honcho | Stateful agents over people/agents/groups/projects/ideas, MCP integration, peer modeling | project/person/team/entity memory views, relationship-aware recall, Codex/MCP recipes | Honcho same-corpus adapter for project/person/task continuity and memory evolution | currently source provenance only; no product-runtime score |
+| OpenViking | Filesystem-like context URIs, hierarchy selection, staged trajectory, recursive expansion | staged Context Pack trajectory, hierarchy-aware routing, recursive expansion trace, rejected-sibling evidence | same-corpus context-trajectory adapter with staged artifacts and hierarchy output | no trajectory parity until staged artifacts exist |
+| agentmemory | Capture hooks, local viewer, coding-agent continuity | source capture hooks, local operator readback, work-resume trace, capture audit | lifecycle/capture/work-resume benchmark rows | capture convenience cannot bypass write policy |
+| claude-mem | Durable local repository memory and progressive disclosure | portable memory summary export, progressive context disclosure, repo-local handoff readback | local continuity fixtures only where not Claude-specific | Claude-only runtime adapters should be removed from Codex/ELF candidates |
+| memsearch | Markdown canonical store, incremental reindex, local hybrid retrieval | exportable Markdown memory snapshots, deterministic reindex, local hybrid recall diagnostics | same-corpus retrieval/evolution/trust rows | ELF source of truth remains Postgres with typed source refs |
+| LangGraph | persistence and work-resume graph patterns | durable agent-state recipes, checkpoint-linked context handoff | persistence/work-resume benchmark rows | not encoded as product-runtime parity yet |
+| graphify | Docker graph-report generation | graph report export and source-linked visualization evidence | product-runtime graph report rows with digest evidence | current tracked row has wrong-result/blocker evidence |
+| llm-wiki/gbrain/nanograph | knowledge compilation, query-save/lint loops, lightweight graph memory ideas | derived page quality, saved-query lint, graph-lite drift tests | typed research-gate rows before scoring | not encoded or blocked rows remain non-pass |
+| Claude/OpenClaw memory files | Simple durable project memory files and just-in-time retrieval | exportable compact memory summaries and Work Journal handoffs | continuity benchmark: reset/resume, rejected option suppression, next-step precision | Claude-specific integrations should be dropped from candidate runtime adapters when not usable by Codex/ELF |
+| LangMem/LangChain | semantic/episodic/procedural memory managers and background formation | typed memory categories, prompt/procedure proposal review, memory manager recipes | extraction/update/delete/consolidation evals by category | memory manager pattern only; not proof of quality |
+| OpenAI Memory/Dreaming | background memory curation, saved memories, chat-history reference, user controls | Dreaming Review queue, memory summary, source links, delete/archive/disable controls | dreaming proposal acceptance, unsupported claim, stale update, deletion, traceability | ELF should be more auditable than opaque background memory |
+| diary/work-journal style systems | session continuity, rejected options, blockers, next steps, assumptions, touched files, and handoff notes | Work Journal capture plus Dreaming proposal generation from journal evidence | journal-to-dreaming-promotion-boundary scenario with source refs, no note/index mutation before approval, queue visibility, unsupported-claim lint, and promotion provenance | diary text is continuity evidence, not current Memory Authority |
+
+## Implementation Roadmap
+
+### R0: Preserve accepted baseline
+
+Keep the July 2026 source-backed project memory contract as the baseline. Do not
+reopen generic Knowledge OS positioning.
+
+Done when:
+
+- README, docs index, specs, and evidence language use the same product position.
+- Existing benchmark reports keep typed non-pass states visible.
+
+### R1: Model ladder and background organizer harness
+
+Add explicit model profiles and job classes for L0/L1/L2/L3/L4.
+
+Implementation targets:
+
+- `model_profile` config for extraction, routing, summarization, judging, and
+  strong review.
+- structured output validators for L2 proposals;
+- escalation policy from L2 to L3;
+- failure classes for schema invalidity, unsupported claim, source-ref miss,
+  contradiction miss, stale miss, and cross-scope leak.
+
+Benchmark targets:
+
+- small-model extraction F1;
+- JSON validity rate;
+- citation coverage;
+- unsupported claim rate;
+- stale, correction, and delete/tombstone behavior;
+- zero source mutation and zero silent Memory Authority mutation;
+- escalation rate;
+- cost and latency by tier.
+
+### R2: Automatic scope router and Context Pack quality
+
+Make automatic scoping the default agent path.
+
+Implementation targets:
+
+- scope classifier over project/repo/task/source/entity/time/trust layers;
+- automatic pack assembly with no required manual pack selection;
+- route traces and suppression reasons;
+- debug-only pin/disable overrides.
+
+Benchmark targets:
+
+- activation precision;
+- activation recall;
+- wrong-scope activation count;
+- cross-scope leak count;
+- stale-source inclusion count;
+- hot-path latency.
+
+### R3: Reproducible benchmark substrate
+
+Make competitor work reproducible before claiming adapter parity.
+
+Implementation targets:
+
+- Docker Compose runner for ELF and comparable adapters;
+- immutable container image digest capture, with local image IDs recorded only as
+  weaker local provenance when no registry digest exists;
+- product commit capture;
+- held-out corpus manifest;
+- leakage audit;
+- same-corpus source-id mapping;
+- bounded public report generation.
+
+Benchmark targets:
+
+- product-runtime pass rows;
+- competitor row-level metrics;
+- typed blocker preservation;
+- no unqualified leaderboard claims.
+
+### R4: qmd-style recall replay and hybrid retrieval
+
+Close the main ergonomics gap against qmd.
+
+Implementation targets:
+
+- compact top-k JSON;
+- one-command replay lines;
+- dense/sparse/fusion/rerank attribution;
+- dropped evidence and selected-but-not-narrated evidence;
+- local-first mode for deterministic recall diagnostics.
+
+Benchmark targets:
+
+- recall@5, precision@5, MRR, nDCG;
+- replay consistency;
+- qmd candidate replay comparability gate;
+- latency and zero-provider local run evidence.
+
+### R5: Knowledge Workspace tree/wiki adapters
+
+Absorb PageIndex and OpenKB without becoming their clone.
+
+Implementation targets:
+
+- tree artifacts for long docs;
+- source-linked wiki/page exports;
+- concept/entity/decision/timeline pages;
+- watch/rebuild and stale lint;
+- page-delta to memory-candidate proposals.
+
+Benchmark targets:
+
+- source-id mapped PageIndex tree output;
+- source-id mapped OpenKB wiki/index/lint/watch output;
+- citation coverage;
+- stale-source lint correctness;
+- page rebuild diff correctness.
+
+### R6: Memory history, core/archive, and entity views
+
+Absorb mem0/OpenMemory, Letta, and Honcho strengths.
+
+Implementation targets:
+
+- entity-scoped memory history;
+- ADD/UPDATE/DELETE audit readback;
+- export/restore format;
+- core project memory blocks;
+- archival source search;
+- person/team/project/agent relationship views.
+
+Benchmark targets:
+
+- correction persistence;
+- delete/tombstone suppression;
+- entity recall quality;
+- core/archive export/readback mapping;
+- work-continuity reset/resume accuracy.
+
+### R7: Temporal graph and graph/RAG adapters
+
+Add graph strength where it improves memory truth.
+
+Implementation targets:
+
+- valid-from/valid-to relation facts;
+- superseded and stale relation labels;
+- local/global graph recall modes;
+- community/topic reports;
+- citation navigation for graph-derived context.
+
+Benchmark targets:
+
+- stale graph fact suppression;
+- temporal contradiction resolution;
+- graph citation coverage;
+- Graphiti/Zep, GraphRAG, LightRAG, and RAGFlow adapter rows with typed outcomes.
+
+### R8: Work Journal and Dreaming automation
+
+Turn diary and background organization into production-grade loops.
+
+Implementation targets:
+
+- automatic session journal capture;
+- next-step, decision, rejected-option, blocker, and touched-source extraction;
+- daily/weekly dreaming batches;
+- proposal review queue;
+- low-risk derived-page auto-organization;
+- no silent Memory Authority mutation.
+
+Benchmark targets:
+
+- resume accuracy;
+- decision-rationale recall;
+- rejected-option suppression;
+- journal-to-dreaming proposal boundary;
+- journal-only authority claim count;
+- proposal acceptance rate;
+- unsupported dreaming claim rate;
+- source mutation count.
+
+### R9: Operator UI, export, and privacy controls
+
+Build the UI as an operator console, not the primary product surface.
+
+Implementation targets:
+
+- source review;
+- Memory Inbox and Memory Ledger;
+- Knowledge Workspace page browser;
+- Work Journal timeline;
+- Dreaming Review queue;
+- Recall Debug panel;
+- export/delete/restore controls;
+- privacy and scope labels.
+
+Benchmark targets:
+
+- export/readback completeness;
+- delete/archive/restore correctness;
+- UI/export product evidence for OpenMemory-style comparisons;
+- privacy leak counters.
+
+## Benchmark Metrics
+
+Required metrics:
+
+- expected evidence recall;
+- precision@k;
+- MRR;
+- nDCG;
+- source-ref coverage;
+- citation coverage;
+- stale suppression rate;
+- update correctness;
+- correction persistence;
+- delete/tombstone suppression rate;
+- unsupported claim rate;
+- uncertainty handling;
+- trap avoidance;
+- cross-scope leak count;
+- journal-only authority claim count;
+- Context Pack activation precision and recall;
+- route trace coverage;
+- mean and p95 latency;
+- cost by model tier;
+- resource footprint;
+- proposal acceptance rate;
+- small-model escalation rate;
+- product-runtime digest and commit provenance.
+
+Product-specific metrics may add:
+
+- qmd replay consistency;
+- PageIndex tree-node citation coverage;
+- OpenKB wiki rebuild diff correctness;
+- mem0 history event correctness;
+- Letta core/archive readback coverage;
+- Graphiti/Zep temporal invalidation correctness;
+- RAGFlow layout/table provenance coverage;
+- GraphRAG community summary grounding;
+- LightRAG local/global/hybrid mode correctness;
+- Honcho project/person continuity quality.
+
+## Decodex Execution Plan
+
+Queue only one accepted slice at a time:
+
+1. README/product-position drift cleanup and plan promotion.
+2. R1 model ladder and background organizer benchmark.
+3. R2 automatic scope router and Context Pack quality.
+4. R3 reproducible benchmark substrate.
+5. R4 qmd replay parity.
+6. R5 PageIndex/OpenKB tree/wiki adapters.
+7. R6 memory history/core/archive/entity views.
+8. R7 temporal graph and graph/RAG adapters.
+9. R8 Work Journal and Dreaming automation.
+10. R9 operator UI/export/privacy.
+
+Every Decodex issue must include:
+
+- owning spec or plan reference;
+- exact files/modules in scope;
+- required benchmark task;
+- allowed and disallowed claims;
+- competitor rows touched;
+- review requirements;
+- no broad refactor unless it directly improves the slice's measured quality.
+
+## Claim Rules
+
+Allowed now:
+
+- ELF is open-source, source-backed project memory for AI agents.
+- ELF has strong checked-in evidence for source-backed memory authority, lifecycle,
+  recall debug, Context Pack routing, and measured source-backed quality slices.
+- Priority tracked competitor strengths are mapped to optimization lanes, while
+  unencoded or blocked scoreboard rows remain explicit future evidence targets.
+
+Not allowed now:
+
+- ELF beats every competitor.
+- ELF is the best generic Knowledge OS.
+- ELF has product-runtime parity with qmd, PageIndex, OpenKB, mem0/OpenMemory,
+  Letta, Graphiti/Zep, Honcho, RAGFlow, GraphRAG, or LightRAG.
+- Fixture-backed, blocked, wrong-result, incomplete, or not-encoded rows are wins.
+
+## Completion Criteria
+
+This plan is implementation-ready only after:
+
+- docs validation passes;
+- skeptic challenge P0/P1 objections are resolved or recorded as blockers;
+- README positioning drift is removed;
+- any accepted changes are promoted to the owning spec before being treated as
+  normative;
+- Decodex issues are queued one phase at a time with benchmark and review gates.

--- a/docs/reference/plans/index.md
+++ b/docs/reference/plans/index.md
@@ -36,3 +36,4 @@ accepted durable claims into `docs/spec/`, `docs/runbook/`, `docs/decisions/`,
 - `2026-03-01-reflection-consolidation-loop-eval-scenarios.md`: retained historical plan artifact.
 - `2026-03-04-search-modes-design.md`: retained historical plan artifact.
 - `2026-06-08-elf-hardening-evaluation-decisions.md`: retained historical plan artifact.
+- `2026-07-03-source-backed-memory-knowledge-roadmap.md`: retained source-backed memory, knowledge workspace, work journal, dreaming, model ladder, competitor absorption, and benchmark roadmap.


### PR DESCRIPTION
## Summary
- add the retained source-backed memory + knowledge roadmap under docs/reference/plans
- align README positioning with the source-backed project memory contract
- update the plan index and docs log

## Validation
- cargo make check-docs

## Claim boundaries
- this is a retained planning artifact; docs/spec/agent_memory_knowledge_system_v1.md remains normative
- no broad competitor superiority, hosted parity, private/provider-backed quality, or small-model authority claim is made